### PR TITLE
add ColorTypes to test/REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 IndirectArrays
+ColorTypes


### PR DESCRIPTION
it's probably an indirect dependency of something else, but unless
that's guaranteed to always be the case it should be listed explicitly