### PR TITLE
update to 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 1.0
 FixedPointNumbers 0.3.0
 ColorTypes
 ColorVectorSpace

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 1.0
+julia 0.7
 FixedPointNumbers 0.3.0
 ColorTypes
 ColorVectorSpace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -17,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"Netpbm\"); Pkg.build(\"Netpbm\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"Netpbm\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/Netpbm.jl
+++ b/src/Netpbm.jl
@@ -36,11 +36,11 @@ function load(s::Stream{format"PGMBinary"})
     w, h = parse_netpbm_size(io)
     maxval = parse_netpbm_maxval(io)
     if maxval <= 255
-        dat8 = Array{UInt8}(h, w)
+        dat8 = Array{UInt8}(undef, h, w)
         readio!(io, dat8)
         return reinterpret(Gray{N0f8}, dat8)
     elseif maxval <= typemax(UInt16)
-        datraw = Array{UInt16}(h, w)
+        datraw = Array{UInt16}(undef, h, w)
         readio!(io, datraw)
         # Determine the appropriate Normed type
         T = ufixedtype[ceil(Int, log2(maxval)/2)<<1]
@@ -56,21 +56,21 @@ function load(s::Stream{format"PPMBinary"})
     maxval = parse_netpbm_maxval(io)
     local dat
     if maxval <= 255
-        dat8 = Array{UInt8}(3, h, w)
+        dat8 = Array{UInt8}(undef, 3, h, w)
         readio!(io, dat8)
-        return reinterpret(RGB{N0f8}, dat8)
+        return reshape(reinterpret(RGB{N0f8}, dat8), (h, w))
     elseif maxval <= typemax(UInt16)
-        datraw = Array{UInt16}(3, h, w)
+        datraw = Array{UInt16}(undef, 3, h, w)
         readio!(io, datraw)
         # Determine the appropriate Normed type
         T = ufixedtype[ceil(Int, log2(maxval)/2)<<1]
-        return reinterpret(RGB{T}, datraw)
+        return reshape(reinterpret(RGB{T}, datraw), (h, w))
     else
         error("Image file may be corrupt. Are there really more than 16 bits in this image?")
     end
 end
 
-@noinline function readio!{T}(io, dat::AbstractMatrix{T})
+@noinline function readio!(io, dat::AbstractMatrix{T}) where {T}
     h, w = size(dat)
     for i = 1:h, j = 1:w  # io is stored in row-major format
         dat[i,j] = default_swap(read(io, T))
@@ -78,7 +78,7 @@ end
     dat
 end
 
-@noinline function readio!{T}(io, dat::AbstractArray{T,3})
+@noinline function readio!(io, dat::AbstractArray{T,3}) where {T}
     size(dat, 1) == 3 || throw(DimensionMismatch("must be of size 3 in first dimension, got $(size(dat, 1))"))
     h, w = size(dat, 2), size(dat, 3)
     for i = 1:h, j = 1:w, k = 1:3  # io is stored row-major, color-first
@@ -112,7 +112,7 @@ function save(s::Stream, img::AbstractMatrix; mapf=identity, mapi=nothing)
     save(s, img, mapf)
 end
 
-@noinline function save{T<:Union{Gray,Number}}(s::Stream{format"PGMBinary"}, img::AbstractMatrix{T}, mapf)
+@noinline function save(s::Stream{format"PGMBinary"}, img::AbstractMatrix{T}, mapf) where {T<:Union{Gray,Number}}
     h, w = size(img)
     Tout, mx = pnmmax(img)
     if sizeof(Tout) > 2
@@ -125,7 +125,7 @@ end
     nothing
 end
 
-@noinline function save{T<:Color}(s::Stream{format"PPMBinary"}, img::AbstractMatrix{T}, mapf)
+@noinline function save(s::Stream{format"PPMBinary"}, img::AbstractMatrix{T}, mapf) where {T<:Color}
     h, w = size(img)
     Tout, mx = pnmmax(img)
     if sizeof(Tout) > 2
@@ -150,19 +150,17 @@ function parse_netpbm_size(stream::IO)
 end
 
 function parse_netpbm_maxval(stream::IO)
-    skipchars(stream, isspace, linecomment='#')
+    skipchars(isspace, stream, linecomment='#')
     maxvalline = strip(readline(stream))
     parse(Int, maxvalline)
 end
 
 function parseints(line, n)
-    ret = Vector{Int}(n)
+    ret = Vector{Int}(undef, n)
     pos = 1
     for i = 1:n
-        pos2 = search(line, ' ', pos)
-        if pos2 == 0
-            pos2 = length(line)+1
-        end
+        space = findnext(" ", line, pos)
+        pos2 = space === nothing ? length(line)+1 : space[1]
         ret[i] = parse(Int, line[pos:pos2-1])
         pos = pos2+1
         if pos > length(line) && i < n
@@ -173,8 +171,8 @@ function parseints(line, n)
 
 end
 
-function pnmmax{T}(img::AbstractArray{T})
-    if isleaftype(T)
+function pnmmax(img::AbstractArray{T}) where {T}
+    if isconcretetype(T)
         return pnmmax(eltype(T))
     end
     # Determine the concrete type that can hold all the elements
@@ -185,11 +183,11 @@ function pnmmax{T}(img::AbstractArray{T})
     pnmmax(eltype(S))
 end
 
-pnmmax{T<:AbstractFloat}(::Type{T}) = UInt8, 255
-function pnmmax{U<:Normed}(::Type{U})
+pnmmax(::Type{T}) where {T<:AbstractFloat} = UInt8, 255
+function pnmmax(::Type{U}) where {U<:Normed}
     FixedPointNumbers.rawtype(U), reinterpret(one(U))
 end
-pnmmax{T<:Unsigned}(::Type{T}) = T, typemax(T)
+pnmmax(::Type{T}) where {T<:Unsigned} = T, typemax(T)
 
 mybswap(i::Integer)  = bswap(i)
 mybswap(i::Normed)   = bswap(i)

--- a/src/Netpbm.jl
+++ b/src/Netpbm.jl
@@ -159,8 +159,8 @@ function parseints(line, n)
     ret = Vector{Int}(undef, n)
     pos = 1
     for i = 1:n
-        space = findnext(" ", line, pos)
-        pos2 = space === nothing ? length(line)+1 : space[1]
+        pos2 = findnext(isequal(' '), line, pos)
+        pos2 = pos2 === nothing ? length(line)+1 : pos2
         ret[i] = parse(Int, line[pos:pos2-1])
         pos = pos2+1
         if pos > length(line) && i < n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Netpbm, ColorTypes, FixedPointNumbers, IndirectArrays, ImageCore, FileIO
-using Base.Test
+using Test
 
 @testset "IO" begin
     workdir = joinpath(tempdir(), "Images")
@@ -46,14 +46,14 @@ using Base.Test
     end
 
     @testset "Colormap" begin
-        datafloat = reshape(linspace(0.5, 1.5, 6), 2, 3)
+        datafloat = reshape(range(0.5, stop=1.5, length=6), 2, 3)
         dataint = map(x->round(UInt8, x), 254*(datafloat .- 0.5) .+ 1) # ranges 1 to 255
         # build our colormap
         b = RGB(0,0,1)
         w = RGB(1,1,1)
         r = RGB(1,0,0)
-        cmaprgb = Array{RGB{N0f8}}(255)
-        f = linspace(0,1,128)
+        cmaprgb = Array{RGB{N0f8}}(undef, 255)
+        f = range(0, stop=1, length=128)
         cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = IndirectArray(dataint, cmaprgb)
@@ -61,8 +61,8 @@ using Base.Test
         Netpbm.save(fn, img)
         imgr = Netpbm.load(fn)
         @test imgr == img
-        cmaprgb = Array{RGB}(255) # poorly-typed cmap, Images issue #336
-        @test !isleaftype(eltype(cmaprgb))
+        cmaprgb = Array{RGB}(undef, 255) # poorly-typed cmap, Images issue #336
+        @test !isconcretetype(eltype(cmaprgb))
         cmaprgb[1:128] = RGB{N0f16}[(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = RGB{N4f12}[(1-x)*w + x*r for x in f[2:end]]
         img = IndirectArray(dataint, cmaprgb)


### PR DESCRIPTION
I tried to get this package to pass its tests in Julia 1.0.

I recently came back to Julia again after missing quite a lot of changes from 0.6 to 1.0, so I'm not sure if I missed anything. Especially: the two reshape calls (https://github.com/JuliaIO/Netpbm.jl/compare/master...ikirill:fix-1.0?expand=1#diff-6a5223fa47122047e1edceed76f383aaR61) and the findnext call (https://github.com/JuliaIO/Netpbm.jl/compare/master...ikirill:fix-1.0?expand=1#diff-6a5223fa47122047e1edceed76f383aaR162) are two places where the replacements are simple, but maybe idiomatic Julia would have expected me to do something else.