### PR TITLE
don't directly depend on ColorTypes and FixedPointNumbers 

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 00 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -3,24 +3,19 @@ uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
 version = "0.4.0"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 
 [compat]
-julia = "1"
-ColorTypes = "0.8"
 ColorVectorSpace = "0.8"
 FileIO = "1"
-FixedPointNumbers = "0.6"
-ImageCore = "0.8"
+ImageCore = "0.8.1"
+julia = "1"
 
 [extras]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorTypes", "Test", "IndirectArrays"]
+test = ["Test", "IndirectArrays"]

--- a/src/Netpbm.jl
+++ b/src/Netpbm.jl
@@ -1,7 +1,6 @@
 module Netpbm
 
-using FileIO, FixedPointNumbers, ColorTypes, ColorVectorSpace, ImageCore
-using ColorTypes: AbstractGray
+using FileIO, ColorVectorSpace, ImageCore
 
 # Note: there is no endian standard, but netpbm is big-endian
 const is_little_endian = ENDIAN_BOM == 0x04030201

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Netpbm, ColorTypes, FixedPointNumbers, IndirectArrays, ImageCore, FileIO
+using Netpbm, IndirectArrays, ImageCore, FileIO
 using Test
 
 @testset "IO" begin


### PR DESCRIPTION
Similar to https://github.com/JuliaIO/QuartzImageIO.jl/pull/66

This removes the direct dependency on FixedPointNumbers and ColorTypes so that compat maintenance is less a pain.

closes https://github.com/JuliaIO/QuartzImageIO.jl/issues/68