### PR TITLE
Arrays with non-default indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,8 @@ julia = "1"
 
 [extras]
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "IndirectArrays"]
+test = ["Test", "IndirectArrays", "OffsetArrays"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Netpbm, IndirectArrays, ImageCore, FileIO
+using Netpbm, IndirectArrays, ImageCore, FileIO, OffsetArrays
 using Test
 
 @testset "IO" begin
@@ -7,7 +7,7 @@ using Test
     mkdir(workdir)
 
     @testset "Bicolor pbm" begin
-        # 20 colums = 2.5 bytes
+        # 20 columns = 2.5 bytes
         af = rand(0:1, 3, 20)
         for fmt in (format"PBMBinary", format"PBMText")
             for T in (Bool, Int)
@@ -109,6 +109,26 @@ using Test
         B = Netpbm.load(fn)
         A[1,1] = 0
         @test B == Gray{N0f8}.(A)
+    end
+
+    @testset "OffsetArrays" begin
+        ac = OffsetArray(rand(Bool, 3, 20), -1:1, 0:19)
+        fn = File(format"PBMText", joinpath(workdir, "20by3.pbm"))
+        Netpbm.save(fn, ac)
+        b = Netpbm.load(fn)
+        @test b[1:end] == ac[1:end]
+
+        ac = OffsetArray(rand(Gray{N0f8}, 2, 3), 0:1, -1:1)
+        fn = File(format"PGMText", joinpath(workdir, "3by2.pgm"))
+        Netpbm.save(fn, ac)
+        b = Netpbm.load(fn)
+        @test b[1:end] == ac[1:end]
+
+        ac = OffsetArray(rand(RGB{N0f8}, 2, 3), 0:1, -1:1)
+        fn = File(format"PPMText", joinpath(workdir, "3by2.ppm"))
+        Netpbm.save(fn, ac)
+        b = Netpbm.load(fn)
+        @test b[1:end] == ac[1:end]
     end
 end
 


### PR DESCRIPTION
As suggested for PR https://github.com/JuliaIO/Netpbm.jl/pull/23, this code accommodates the use of arrays with non-default indexing. Tests now include examples using [OffsetArrays](https://github.com/JuliaArrays/OffsetArrays.jl).