### PR TITLE
[compat/CI] maintenance upgrade

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         version:
           - '1.0'
           - '1'
-#          - 'nightly'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,16 +1,25 @@
 name: CompatHelper
-
 on:
   schedule:
-    - cron: '00 00 * * *'
-
+    - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Netpbm"
 uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 
 [compat]
-ColorVectorSpace = "0.8"
+ColorVectorSpace = "0.8, 0.9"
 FileIO = "1"
 ImageCore = "0.8.1"
 julia = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Test
         for fmt in (format"PBMBinary", format"PBMText")
             for T in (Bool, Int)
                 ac = convert(Array{T}, af)
-                fn = File(fmt, joinpath(workdir, "20by3.pbm"))
+                fn = File{fmt}(joinpath(workdir, "20by3.pbm"))
                 Netpbm.save(fn, ac)
                 b = Netpbm.load(fn)
                 @test b == ac
@@ -26,7 +26,7 @@ using Test
             for T in (N0f8, N4f12, N0f16,
                       Gray{N0f8}, Gray{N4f12}, Gray{N0f16})
                 ac = convert(Array{T}, af)
-                fn = File(fmt, joinpath(workdir, "3by2.pgm"))
+                fn = File{fmt}(joinpath(workdir, "3by2.pgm"))
                 Netpbm.save(fn, ac)
                 b = Netpbm.load(fn)
                 @test b == ac
@@ -36,7 +36,7 @@ using Test
         for fmt in (format"PGMBinary", format"PGMText")
             for T in (Float32, Float64, Gray{Float32}, Gray{Float64})
                 ac = convert(Array{T}, af)
-                fn = File(fmt, joinpath(workdir, "3by2.pgm"))
+                fn = File{fmt}(joinpath(workdir, "3by2.pgm"))
                 Netpbm.save(fn, ac)
                 b = Netpbm.load(fn)
                 @test b == a8
@@ -52,7 +52,7 @@ using Test
         for fmt in (format"PPMBinary", format"PPMText")
             for T in (RGB{N0f8}, RGB{N4f12}, RGB{N0f16})
                 ac = convert(Array{T}, af)
-                fn = File(fmt, joinpath(workdir, "3by2.ppm"))
+                fn = File{fmt}(joinpath(workdir, "3by2.ppm"))
                 Netpbm.save(fn, ac)
                 b = Netpbm.load(fn)
                 @test b == ac
@@ -62,7 +62,7 @@ using Test
         for fmt in (format"PPMBinary", format"PPMText")
             for T in (RGB{Float32}, RGB{Float64}, HSV{Float64})
                 ac = convert(Array{T}, af)
-                fn = File(fmt, joinpath(workdir, "3by2.ppm"))
+                fn = File{fmt}(joinpath(workdir, "3by2.ppm"))
                 Netpbm.save(fn, ac)
                 b = Netpbm.load(fn)
                 @test b == a8
@@ -82,7 +82,7 @@ using Test
         cmaprgb[1:128] = [(1-x)*b + x*w for x in f]
         cmaprgb[129:end] = [(1-x)*w + x*r for x in f[2:end]]
         img = IndirectArray(dataint, cmaprgb)
-        fn = File(format"PPMBinary", joinpath(workdir,"cmap.ppm"))
+        fn = File{format"PPMBinary"}(joinpath(workdir,"cmap.ppm"))
         Netpbm.save(fn, img)
         imgr = Netpbm.load(fn)
         @test imgr == img
@@ -103,7 +103,7 @@ using Test
     @testset "Clamping" begin
         A = rand(2,3)
         A[1,1] = -0.4
-        fn = File(format"PGMBinary", joinpath(workdir, "2by3.pgm"))
+        fn = File{format"PGMBinary"}(joinpath(workdir, "2by3.pgm"))
         @test_throws InexactError Netpbm.save(fn, A)
         Netpbm.save(fn, A, mapf=clamp01nan)
         B = Netpbm.load(fn)
@@ -113,19 +113,19 @@ using Test
 
     @testset "OffsetArrays" begin
         ac = OffsetArray(rand(Bool, 3, 20), -1:1, 0:19)
-        fn = File(format"PBMText", joinpath(workdir, "20by3.pbm"))
+        fn = File{format"PBMText"}(joinpath(workdir, "20by3.pbm"))
         Netpbm.save(fn, ac)
         b = Netpbm.load(fn)
         @test b[1:end] == ac[1:end]
 
         ac = OffsetArray(rand(Gray{N0f8}, 2, 3), 0:1, -1:1)
-        fn = File(format"PGMText", joinpath(workdir, "3by2.pgm"))
+        fn = File{format"PGMText"}(joinpath(workdir, "3by2.pgm"))
         Netpbm.save(fn, ac)
         b = Netpbm.load(fn)
         @test b[1:end] == ac[1:end]
 
         ac = OffsetArray(rand(RGB{N0f8}, 2, 3), 0:1, -1:1)
-        fn = File(format"PPMText", joinpath(workdir, "3by2.ppm"))
+        fn = File{format"PPMText"}(joinpath(workdir, "3by2.ppm"))
         Netpbm.save(fn, ac)
         b = Netpbm.load(fn)
         @test b[1:end] == ac[1:end]


### PR DESCRIPTION
Eventually, we'll remove the direct dependency on ColorVectorSpace and just use ImageCore 0.9 https://github.com/JuliaImages/ImageCore.jl/pull/157