### PR TITLE
Added code for storing metadata in netpbm images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.2"
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 
 [compat]
 FileIO = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Netpbm"
 uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -10,6 +10,7 @@ ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
 [compat]
 FileIO = "1"
 ImageCore = "0.9"
+ImageMetadata = "0.9"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Netpbm"
 uuid = "f09324ee-3d7c-5217-9330-fc30815ba969"
-version = "1.0.3"
+version = "1.1.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ packages, such as
 such formats. One advantage of this package is that it does not have
 any binary (e.g., external library) dependencies---it is implemented
 in pure Julia.
+
+The package accepts [Metadata](https://github.com/JuliaImages/ImageMetadata.jl)
+types to save, saving image metadata as
+[Netpbm](https://en.wikipedia.org/wiki/Netpbm_format) comments.

--- a/src/Netpbm.jl
+++ b/src/Netpbm.jl
@@ -1,6 +1,6 @@
 module Netpbm
 
-using FileIO, ImageCore
+using FileIO, ImageCore, ImageMetadata
 
 # Note: there is no endian standard, but netpbm is big-endian
 const is_little_endian = ENDIAN_BOM == 0x04030201
@@ -156,62 +156,62 @@ end
     dat
 end
 
-function save(filename::File{format"PBMBinary"}, img; mapf=identity, mapi=nothing)
+function save(filename::File{format"PBMBinary"}, img; mapf=identity, mapi=nothing, comment=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P4\n")
-        write(io, "# pbm file written by Julia\n")
+        write(io, comment === nothing ? "# pbm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PGMBinary"}, img; mapf=identity, mapi=nothing)
+function save(filename::File{format"PGMBinary"}, img; mapf=identity, mapi=nothing, comment=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P5\n")
-        write(io, "# pgm file written by Julia\n")
+        write(io, comment === nothing ? "# pgm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PPMBinary"}, img; mapf=identity, mapi=nothing)
+function save(filename::File{format"PPMBinary"}, img; mapf=identity, mapi=nothing, comment=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P6\n")
-        write(io, "# ppm file written by Julia\n")
+        write(io, comment === nothing ? "# ppm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PBMText"}, img; mapf=identity, mapi=nothing)
+function save(filename::File{format"PBMText"}, img; mapf=identity, mapi=nothing, comment=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P1\n")
-        write(io, "# pbm file written by Julia\n")
+        write(io, comment === nothing ? "# pbm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PGMText"}, img; mapf=identity, mapi=nothing)
+function save(filename::File{format"PGMText"}, img; mapf=identity, mapi=nothing, comment=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P2\n")
-        write(io, "# pgm file written by Julia\n")
+        write(io, comment === nothing ? "# pbm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PPMText"}, img; mapf=identity, mapi=nothing)
+function save(filename::File{format"PPMText"}, img; mapf=identity, mapi=nothing, comment=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P3\n")
-        write(io, "# ppm file written by Julia\n")
+        write(io, comment === nothing ? "# ppm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
@@ -403,6 +403,45 @@ function kwrename(newname, newval, oldname, oldval, caller::Symbol)
         return oldval
     end
     newval
+end
+
+function _read_metadata_string(img::ImageMeta)
+    buf = IOBuffer()
+    for (i, (k, v)) in enumerate(properties(img))
+        i > 1 && write(buf, '\n')
+        print(buf, "# ", k, ": ", v)
+    end
+    return String(take!(buf))
+end
+
+function save(filename::File{format"PBMBinary"}, img::ImageMeta; mapf=identity, mapi=nothing)
+    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
+    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
+end
+
+function save(filename::File{format"PGMBinary"}, img::ImageMeta; mapf=identity, mapi=nothing)
+    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
+    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
+end
+
+function save(filename::File{format"PPMBinary"}, img::ImageMeta; mapf=identity, mapi=nothing)
+    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
+    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
+end
+
+function save(filename::File{format"PBMText"}, img::ImageMeta; mapf=identity, mapi=nothing)
+    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
+    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
+end
+
+function save(filename::File{format"PGMText"}, img::ImageMeta; mapf=identity, mapi=nothing)
+    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
+    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
+end
+
+function save(filename::File{format"PPMText"}, img::ImageMeta; mapf=identity, mapi=nothing)
+    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
+    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
 end
 
 end # module

--- a/src/Netpbm.jl
+++ b/src/Netpbm.jl
@@ -6,6 +6,10 @@ using FileIO, ImageCore, ImageMetadata
 const is_little_endian = ENDIAN_BOM == 0x04030201
 const ufixedtype = Dict(10=>N6f10, 12=>N4f12, 14=>N2f14, 16=>N0f16)
 
+if VERSION < v"1.1"
+    isnothing(x) = x === nothing
+end
+
 function load(f::Union{File{format"PBMBinary"},File{format"PGMBinary"},File{format"PPMBinary"}})
     open(f) do s
         skipmagic(s)

--- a/src/Netpbm.jl
+++ b/src/Netpbm.jl
@@ -156,62 +156,68 @@ end
     dat
 end
 
-function save(filename::File{format"PBMBinary"}, img; mapf=identity, mapi=nothing, comment=nothing)
+function save(filename::File{format"PBMBinary"}, img; mapf=identity, mapi=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
+    comment = _read_metadata(img)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P4\n")
-        write(io, comment === nothing ? "# pbm file written by Julia" : comment, "\n")
+        write(io, isnothing(comment) ? "# pbm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PGMBinary"}, img; mapf=identity, mapi=nothing, comment=nothing)
+function save(filename::File{format"PGMBinary"}, img; mapf=identity, mapi=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
+    comment = _read_metadata(img)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P5\n")
-        write(io, comment === nothing ? "# pgm file written by Julia" : comment, "\n")
+        write(io, isnothing(comment) ? "# pgm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PPMBinary"}, img; mapf=identity, mapi=nothing, comment=nothing)
+function save(filename::File{format"PPMBinary"}, img; mapf=identity, mapi=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
+    comment = _read_metadata(img)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P6\n")
-        write(io, comment === nothing ? "# ppm file written by Julia" : comment, "\n")
+        write(io, isnothing(comment) ? "# ppm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PBMText"}, img; mapf=identity, mapi=nothing, comment=nothing)
+function save(filename::File{format"PBMText"}, img; mapf=identity, mapi=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
+    comment = _read_metadata(img)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P1\n")
-        write(io, comment === nothing ? "# pbm file written by Julia" : comment, "\n")
+        write(io, isnothing(comment) ? "# pbm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PGMText"}, img; mapf=identity, mapi=nothing, comment=nothing)
+function save(filename::File{format"PGMText"}, img; mapf=identity, mapi=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
+    comment = _read_metadata(img)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P2\n")
-        write(io, comment === nothing ? "# pbm file written by Julia" : comment, "\n")
+        write(io, isnothing(comment) ? "# pbm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
 
-function save(filename::File{format"PPMText"}, img; mapf=identity, mapi=nothing, comment=nothing)
+function save(filename::File{format"PPMText"}, img; mapf=identity, mapi=nothing)
     mapf = kwrename(:mapf, mapf, :mapi, mapi, :save)
+    comment = _read_metadata(img)
     open(filename, "w") do s
         io = stream(s)
         write(io, "P3\n")
-        write(io, comment === nothing ? "# ppm file written by Julia" : comment, "\n")
+        write(io, isnothing(comment) ? "# ppm file written by Julia" : comment, "\n")
         save(s, img, mapf=mapf)
     end
 end
@@ -405,43 +411,16 @@ function kwrename(newname, newval, oldname, oldval, caller::Symbol)
     newval
 end
 
-function _read_metadata_string(img::ImageMeta)
+_read_metadata(img::AbstractArray) = nothing
+
+function _read_metadata(img::ImageMeta)
+    isempty(properties(img)) && return nothing
     buf = IOBuffer()
     for (i, (k, v)) in enumerate(properties(img))
         i > 1 && write(buf, '\n')
         print(buf, "# ", k, ": ", v)
     end
     return String(take!(buf))
-end
-
-function save(filename::File{format"PBMBinary"}, img::ImageMeta; mapf=identity, mapi=nothing)
-    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
-    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
-end
-
-function save(filename::File{format"PGMBinary"}, img::ImageMeta; mapf=identity, mapi=nothing)
-    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
-    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
-end
-
-function save(filename::File{format"PPMBinary"}, img::ImageMeta; mapf=identity, mapi=nothing)
-    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
-    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
-end
-
-function save(filename::File{format"PBMText"}, img::ImageMeta; mapf=identity, mapi=nothing)
-    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
-    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
-end
-
-function save(filename::File{format"PGMText"}, img::ImageMeta; mapf=identity, mapi=nothing)
-    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
-    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
-end
-
-function save(filename::File{format"PPMText"}, img::ImageMeta; mapf=identity, mapi=nothing)
-    metadata = isempty(properties(img)) ? nothing : _read_metadata_string(img)
-    save(filename, arraydata(img); mapf=mapf, mapi=mapi, comment=metadata)
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Netpbm, IndirectArrays, ImageCore, FileIO, OffsetArrays
+using Netpbm, IndirectArrays, ImageCore, FileIO, OffsetArrays, ImageMetadata
 using Test
 
 @testset "IO" begin
@@ -6,14 +6,29 @@ using Test
     isdir(workdir) && rm(workdir, recursive=true)
     mkdir(workdir)
 
+    function compare_metadata(fn, meta)
+        info = readlines(filename(fn))
+        expect = sort!(["# $k: $v" for (k, v) in properties(meta)])
+        actual = sort(view(info, 2:(1+length(properties(meta)))))
+        @test expect == actual
+    end
+
     @testset "Bicolor pbm" begin
         # 20 columns = 2.5 bytes
         af = rand(0:1, 3, 20)
         for fmt in (format"PBMBinary", format"PBMText")
             for T in (Bool, Int)
+                # test save/load without metadata
                 ac = convert(Array{T}, af)
                 fn = File{fmt}(joinpath(workdir, "20by3.pbm"))
                 Netpbm.save(fn, ac)
+                b = Netpbm.load(fn)
+                @test b == ac
+
+                # test save with metadata, test metadata content, and correct loading
+                meta = ImageMeta(ac, author = "anonymous", time = "now", comment = "something interesting")
+                Netpbm.save(fn, meta)
+                compare_metadata(fn, meta)
                 b = Netpbm.load(fn)
                 @test b == ac
             end
@@ -25,9 +40,17 @@ using Test
         for fmt in (format"PGMBinary", format"PGMText")
             for T in (N0f8, N4f12, N0f16,
                       Gray{N0f8}, Gray{N4f12}, Gray{N0f16})
+                # test save/load without metadata
                 ac = convert(Array{T}, af)
                 fn = File{fmt}(joinpath(workdir, "3by2.pgm"))
                 Netpbm.save(fn, ac)
+                b = Netpbm.load(fn)
+                @test b == ac
+
+                # test save with metadata, test metadata content, and correct loading
+                meta = ImageMeta(ac, author = "anonymous", time = "now", comment = "something interesting")
+                Netpbm.save(fn, meta)
+                compare_metadata(fn, meta)
                 b = Netpbm.load(fn)
                 @test b == ac
             end
@@ -35,9 +58,17 @@ using Test
         a8 = convert(Array{N0f8}, af)
         for fmt in (format"PGMBinary", format"PGMText")
             for T in (Float32, Float64, Gray{Float32}, Gray{Float64})
+                # test save/load without metadata
                 ac = convert(Array{T}, af)
                 fn = File{fmt}(joinpath(workdir, "3by2.pgm"))
                 Netpbm.save(fn, ac)
+                b = Netpbm.load(fn)
+                @test b == a8
+
+                # test save with metadata, test metadata content, and correct loading
+                meta = ImageMeta(ac, author = "anonymous", time = "now", comment = "something interesting")
+                Netpbm.save(fn, meta)
+                compare_metadata(fn, meta)
                 b = Netpbm.load(fn)
                 @test b == a8
             end
@@ -51,9 +82,17 @@ using Test
         af = rand(RGB{Float64}, 2, 3)
         for fmt in (format"PPMBinary", format"PPMText")
             for T in (RGB{N0f8}, RGB{N4f12}, RGB{N0f16})
+                # test save/load without metadata
                 ac = convert(Array{T}, af)
                 fn = File{fmt}(joinpath(workdir, "3by2.ppm"))
                 Netpbm.save(fn, ac)
+                b = Netpbm.load(fn)
+                @test b == ac
+
+                # test save with metadata, test metadata content, and correct loading
+                meta = ImageMeta(ac, author = "anonymous", time = "now", comment = "something interesting")
+                Netpbm.save(fn, meta)
+                compare_metadata(fn, meta)
                 b = Netpbm.load(fn)
                 @test b == ac
             end
@@ -61,12 +100,20 @@ using Test
         a8 = convert(Array{RGB{N0f8}}, af)
         for fmt in (format"PPMBinary", format"PPMText")
             for T in (RGB{Float32}, RGB{Float64}, HSV{Float64})
+                # test save/load without metadata
                 ac = convert(Array{T}, af)
                 fn = File{fmt}(joinpath(workdir, "3by2.ppm"))
                 Netpbm.save(fn, ac)
                 b = Netpbm.load(fn)
                 @test b == a8
-            end
+
+                # test save with metadata, test metadata content, and correct loading
+                meta = ImageMeta(ac, author = "anonymous", time = "now", comment = "something interesting")
+                Netpbm.save(fn, meta)
+                compare_metadata(fn, meta)
+                b = Netpbm.load(fn)
+                @test b == a8
+           end
         end
     end
 


### PR DESCRIPTION
The `save` methods now accept arguments of type `ImageMeta` from [ImageMetadata.jl](https://github.com/JuliaImages/ImageMetadata.jl). The properties in objects are saved as comments in the image files.

Tests for reading and writing files with and without metadata have been added.

This adds to the dependencies of `Netpbm.jl`, which might be a reason to reject these changes.